### PR TITLE
Fix to shifting widths when using custom columns

### DIFF
--- a/js/hicpo.js
+++ b/js/hicpo.js
@@ -48,9 +48,9 @@
 	
 	$(document).ready(function(){
 
+		var hicpoFixHeaders = function(){
 		// this will add static widths to the header cells, 
 		// to avoid shifting width on drag when using custom columns
-		var hicpoFixHeaders = function(){
 			$('.wp-list-table thead th, .wp-list-table thead td')
 			.each(function(){
 				$(this).css('width', $(this).width());

--- a/js/hicpo.js
+++ b/js/hicpo.js
@@ -46,14 +46,42 @@
 	});
 	//$("#the-list").disableSelection();
 	
-	// this will add static widths to the header cells, 
-	// to avoid shifting width on drag when using custom columns
 	$(document).ready(function(){
-		$('.wp-list-table thead th, .wp-list-table thead td')
+
+		// this will add static widths to the header cells, 
+		// to avoid shifting width on drag when using custom columns
+		var hicpoFixHeaders = function(){
+			$('.wp-list-table thead th, .wp-list-table thead td')
 			.each(function(){
 				$(this).css('width', $(this).width());
 			});
-	});
 
+			console.log('headers');
+		}; 
+		// load on startup
+		hicpoFixHeaders();
+
+
+		var hicpoResetHeaders = function(){
+			// this will reset headers and body cells
+			$('.wp-list-table thead th, .wp-list-table thead td')
+			.each(function(){
+				$(this).css('width', '');
+			});
+			$('.wp-list-table tbody th, .wp-list-table tbody td')
+			.each(function(){
+				$(this).css('width', '');
+			});
+			console.log('headers');
+		}; 
+
+		// reset on window resize 
+		$( window ).resize(function() {
+			console.log('resize');
+			hicpoResetHeaders();
+		  hicpoFixHeaders();
+		});
+
+	});
 
 })(jQuery)

--- a/js/hicpo.js
+++ b/js/hicpo.js
@@ -1,10 +1,25 @@
 (function($){
+
+	var fixStart = function(e, ui) {
+		// this will make the transition smoother by making the placeholder the same height
+		ui.placeholder.height(ui.item.height());
+	};
+
+	var fixHelper = function(e, ui) {
+		// this doesn't work properly at the bottom where it was..so I moved it to the top
+		ui.children().children().each(function() {
+			$(this).width($(this).width());
+		});
+		return ui;
+	};
+
 	
 	// posts
 
 	$('table.posts #the-list, table.pages #the-list').sortable({
 		'items': 'tr',
 		'axis': 'y',
+		'start': fixStart,
 		'helper': fixHelper,
 		'update' : function(e, ui) {
 			$.post( ajaxurl, {
@@ -20,6 +35,7 @@
 	$('table.tags #the-list').sortable({
 		'items': 'tr',
 		'axis': 'y',
+		'start': fixStart,
 		'helper': fixHelper,
 		'update' : function(e, ui) {
 			$.post( ajaxurl, {
@@ -30,11 +46,14 @@
 	});
 	//$("#the-list").disableSelection();
 	
-	var fixHelper = function(e, ui) {
-		ui.children().children().each(function() {
-			$(this).width($(this).width());
-		});
-		return ui;
-	};
-	
+	// this will add static widths to the header cells, 
+	// to avoid shifting width on drag when using custom columns
+	$(document).ready(function(){
+		$('.wp-list-table thead th, .wp-list-table thead td')
+			.each(function(){
+				$(this).css('width', $(this).width());
+			});
+	});
+
+
 })(jQuery)

--- a/js/hicpo.js
+++ b/js/hicpo.js
@@ -55,8 +55,6 @@
 			.each(function(){
 				$(this).css('width', $(this).width());
 			});
-
-			console.log('headers');
 		}; 
 		// load on startup
 		hicpoFixHeaders();
@@ -72,12 +70,10 @@
 			.each(function(){
 				$(this).css('width', '');
 			});
-			console.log('headers');
 		}; 
 
 		// reset on window resize 
 		$( window ).resize(function() {
-			console.log('resize');
 			hicpoResetHeaders();
 		  hicpoFixHeaders();
 		});

--- a/js/hicpo.js
+++ b/js/hicpo.js
@@ -28,7 +28,6 @@
 			});
 		}
 	});
-	//$("#the-list").disableSelection();
 	
 	// tags
 	
@@ -44,8 +43,8 @@
 			});
 		}
 	});
-	//$("#the-list").disableSelection();
-	
+
+	// run after dom has loaded	
 	$(document).ready(function(){
 
 		var hicpoFixHeaders = function(){
@@ -58,7 +57,6 @@
 		}; 
 		// load on startup
 		hicpoFixHeaders();
-
 
 		var hicpoResetHeaders = function(){
 			// this will reset headers and body cells
@@ -75,9 +73,8 @@
 		// reset on window resize 
 		$( window ).resize(function() {
 			hicpoResetHeaders();
-		  hicpoFixHeaders();
+			hicpoFixHeaders();
 		});
-
 	});
 
 })(jQuery)


### PR DESCRIPTION
This fixes the issue reported here:
https://wordpress.org/support/topic/custom-admin-columns-mess-up-post-ordering?replies=3#post-7821529
- Added jQuery function to add static widths to header cells on sortable table
- Fixed placement of fixHelper function so it fires properly
- Added 'fixStart' function to change size of placeholder
