### PR TITLE
Issue #13 - Integrate with WP API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+
+# IntelliJ project files
+.idea
+*.iml
+out
+gen

--- a/intuitive-custom-post-order.php
+++ b/intuitive-custom-post-order.php
@@ -3,7 +3,7 @@
  * Plugin Name: Intuitive Custom Post Order
  * Plugin URI: http://hijiriworld.com/web/plugins/intuitive-custom-post-order/
  * Description: Intuitively, Order Items (Posts, Pages, and Custom Post Types and Custom Taxonomies) using a Drag and Drop Sortable JavaScript.
- * Version: 3.0.7
+ * Version: 3.0.8
  * Author: hijiri
  * Author URI: http://hijiriworld.com/web/
  * Text Domain: intuitive-custom-post-order
@@ -69,7 +69,9 @@ class Hicpo
 		add_action( 'admin_init', array( $this, 'refresh' ) );
 		add_action( 'admin_init', array( $this, 'update_options') );
 		add_action( 'admin_init', array( $this, 'load_script_css' ) );
-		
+
+        add_action( 'init', array( $this, 'register_page_attributes' ) );
+
 		// sortable ajax action
 		add_action( 'wp_ajax_update-menu-order', array( $this, 'update_menu_order' ) );
 		add_action( 'wp_ajax_update-menu-order-tags', array( $this, 'update_menu_order_tags' ) );
@@ -270,6 +272,14 @@ class Hicpo
 			}
 		}
 	}
+
+    /**
+     * register page-attributes so that posts can be ordered by menu_order, when querying using wp-api
+     */
+	function register_page_attributes()
+    {
+        add_post_type_support( "post", "page-attributes" );
+    }
 	
 	/**
 	* はじめて有効化されたオブジェクトは、ディフォルトの order に従って menu_order セットする

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_i
 Tags: post order, posts order, order post, order posts, custom post type order, custom taxonomy order
 Requires at least: 3.5.0
 Tested up to: 4.3.1
-Stable tag: 3.0.7
+Stable tag: 3.0.8
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -81,6 +81,10 @@ add_action( 'pre_get_posts', 'my_filter' );
 Go to "screen options" and change "Number of items per page:".
 
 == Changelog ==
+
+= 3.0.8 =
+
+* Added integration with WP-API - It is now possible to query posts using WP-API, and have them ordered by menu_order, which is the order this plugin imposes
 
 = 3.0.7 =
 


### PR DESCRIPTION
It is now possible to query posts using wp-api, and have them ordered by menu_order, which is the order this plugin imposes
