### PR TITLE
v3.0.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Intuitively, order items( Posts, Pages, and Custom Post Types, and Custom Taxono
 
 Select sortable items from 'Intuitive CPT' menu of Setting menu in WordPress.
 
-In addition, You can re-override the parameters of `orderby` and `order`, by using the `WP_Query` or `pre_get_posts` or `query_posts`.<br>
-The `get_posts()` is excluded.
+In addition, You can re-override the parameters of `orderby` and `order`, by using the `WP_Query` or `pre_get_posts` or `query_posts()` or `get_posts()`.<br>
+ATTENTION: Only if you use `get_posts()` to re-overwrite to the default order( `orderby=date, order=DESC` ), You need to use own custom parameter `orderby=default_date`.
 
 ## Installation
 

--- a/intuitive-custom-post-order.php
+++ b/intuitive-custom-post-order.php
@@ -3,7 +3,7 @@
  * Plugin Name: Intuitive Custom Post Order
  * Plugin URI: http://hijiriworld.com/web/plugins/intuitive-custom-post-order/
  * Description: Intuitively, Order Items (Posts, Pages, and Custom Post Types and Custom Taxonomies) using a Drag and Drop Sortable JavaScript.
- * Version: 3.0.7
+ * Version: 3.0.8
  * Author: hijiri
  * Author URI: http://hijiriworld.com/web/
  * Text Domain: intuitive-custom-post-order
@@ -459,8 +459,12 @@ class Hicpo
 			
 			// get_posts()
 			if ( isset( $wp_query->query['suppress_filters'] ) ) {
-				if ( $wp_query->get( 'orderby' ) == 'date' )  $wp_query->set( 'orderby', 'menu_order' );
-				if ( $wp_query->get( 'order' ) == 'DESC' ) $wp_query->set( 'order', 'ASC' );
+				if ( $wp_query->get( 'orderby' ) == 'date' || $wp_query->get( 'orderby' ) == 'menu_order' ) {
+					$wp_query->set( 'orderby', 'menu_order' );
+					$wp_query->set( 'order', 'ASC' );
+				} elseif($wp_query->get( 'orderby' ) == 'default_date') {
+					$wp_query->set( 'orderby', 'date' );
+				}
 			// WP_Query( contain main_query )
 			} else {
 				if ( !$wp_query->get( 'orderby' ) )  $wp_query->set( 'orderby', 'menu_order' );

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: hijiri
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=TT5NP352P6MCU
 Tags: post order, posts order, order post, order posts, custom post type order, custom taxonomy order
 Requires at least: 3.5.0
-Tested up to: 4.3.1
+Tested up to: 4.7.3
 Stable tag: 3.0.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -16,8 +16,8 @@ Intuitively, order items( Posts, Pages, and Custom Post Types, and Custom Taxono
 
 Select sortable items from 'Intuitive CPT' menu of Setting menu in WordPress.
 
-In addition, You can re-override the parameters of 'orderby' and 'order', by using the 'WP_Query' or 'pre_get_posts' or 'query_posts()'.<br>
-The 'get_posts()' is excluded.
+In addition, You can re-override the parameters of 'orderby' and 'order', by using the 'WP_Query' or 'pre_get_posts' or 'query_posts()' or 'get_posts()'.<br>
+ATTENTION: Only if you use 'get_posts()' to re-overwrite to the default order( orderby=date, order=DESC ), You need to use own custom parameter 'orderby=default_date'.
 
 This Plugin published on <a href="https://github.com/hijiriworld/intuitive-custom-post-order">GitHub.</a>
 
@@ -45,7 +45,24 @@ By using the 'WP_Query', you can re-override the parameters.
 
 `
 <?php $query = new WP_Query( array(
-	'orderby' => 'date',
+	'orderby' => 'ID',
+	'order' => 'DESC',
+) ) ?>
+`
+
+* get_posts()
+
+`
+<?php $query = get_posts( array(
+	'orderby' => 'title',
+) ) ?>
+`
+
+ATTENTION: Only if you use 'get_posts()' to re-overwrite to the default order( orderby=date, order=DESC ), You need to use own custom parameter 'orderby=default_date'.
+
+`
+<?php $query = get_posts( array(
+	'orderby' => 'default_date',
 	'order' => 'DESC',
 ) ) ?>
 `
@@ -82,6 +99,11 @@ Go to "screen options" and change "Number of items per page:".
 
 == Changelog ==
 
+= 3.0.8 =
+
+* Even for 'get_posts()', Your custom Query which uses the 'order' or 'orderby' parameters is preferred.
+  ATTENTION: Only if you use 'get_posts()' to re-overwrite to the default order( orderby=date, order=DESC ), You need to use own custom parameter 'orderby=default_date'.
+
 = 3.0.7 =
 
 * This plugin will imported listed above into the translate.wordpress.org translation system. Language packs will also be enabled for this plugin, for any locales that are fully translated (at 100%).
@@ -98,7 +120,7 @@ Go to "screen options" and change "Number of items per page:".
 
 = 3.0.4 =
 
-* Your Query which uses the 'order' or 'orderby' parameters is preferred.
+* Your custom Query which uses the 'order' or 'orderby' parameters is preferred.
   In order to prefer the parameters of your query, You must use the 'WP_Query()' or 'query_posts()'.
   Excluded 'get_posts()'.
 * Fixed bug


### PR DESCRIPTION
* Even for 'get_posts()', Your custom Query which uses the 'order' or 'orderby' parameters is preferred.
  ATTENTION: Only if you use 'get_posts()' to re-overwrite to the default order( orderby=date, order=DESC ), You need to use own custom parameter 'orderby=default_date'.