### PR TITLE
Responsive drag icon added

### DIFF
--- a/css/hicpo.css
+++ b/css/hicpo.css
@@ -1,8 +1,30 @@
-.ui-sortable tr:hover {
+.ui-sortable .drag-handle {
+	display: none;
+	width: 26px;
+	height: 16px;
+	margin-left: 3px;
+	padding: 5px 0;
+}
+.ui-sortable tr:hover .drag-handle {
+	display: block;
+}
+.ui-sortable .drag-handle:hover {
 	cursor: move;
 }
+.ui-sortable .drag-handle svg {
+	display: block;
+	width: 100%;
+	height: 100%;
+	fill: #333;
+}
+@media screen and (max-width: 782px) {
+	.ui-sortable .drag-handle {
+		display: block;
+		margin-left: 7px;
+	}
+}
 .ui-sortable tr.alternate {
-	background-color: #F9F9F9;	
+	background-color: #F9F9F9;
 }
 .ui-sortable tr.ui-sortable-helper {
 	background-color: #F9F9F9;

--- a/js/hicpo.js
+++ b/js/hicpo.js
@@ -1,11 +1,17 @@
 (function($){
-	
+
+	// Add a 'drag' icon to the table rows
+	$('table.posts #the-list, table.pages #the-list, table.tags #the-list, table.sites #the-list')
+		.find('tr .check-column')
+		.append('<div class="drag-handle"><svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64"><path d="M32 2l18 18H36v24h14L32 62 14 44h14V20H14L32 2z"/></svg></div>');
+
 	// posts
 
 	$('table.posts #the-list, table.pages #the-list').sortable({
 		'items': 'tr',
 		'axis': 'y',
 		'helper': fixHelper,
+		'handle': '.drag-handle',
 		'update' : function(e, ui) {
 			$.post( ajaxurl, {
 				action: 'update-menu-order',
@@ -14,13 +20,14 @@
 		}
 	});
 	//$("#the-list").disableSelection();
-	
+
 	// tags
-	
+
 	$('table.tags #the-list').sortable({
 		'items': 'tr',
 		'axis': 'y',
 		'helper': fixHelper,
+		'handle': '.drag-handle',
 		'update' : function(e, ui) {
 			$.post( ajaxurl, {
 				action: 'update-menu-order-tags',
@@ -29,9 +36,9 @@
 		}
 	});
 	//$("#the-list").disableSelection();
-	
+
 	// sites
-	
+
 	// add number
 	var site_table_tr = $('table.sites #the-list tr');
 	site_table_tr.each( function() {
@@ -50,11 +57,12 @@
 		}
 		$(this).attr('id','site-'+ret);
 	} );
-	
+
 	$('table.sites #the-list').sortable({
 		'items': 'tr',
 		'axis': 'y',
 		'helper': fixHelper,
+		'handle': '.drag-handle',
 		'update' : function(e, ui) {
 			$.post( ajaxurl, {
 				action: 'update-menu-order-sites',
@@ -62,12 +70,12 @@
 			});
 		}
 	});
-	
+
 	var fixHelper = function(e, ui) {
 		ui.children().children().each(function() {
 			$(this).width($(this).width());
 		});
 		return ui;
 	};
-	
+
 })(jQuery)


### PR DESCRIPTION
This aims to fix an issue where you can't click the other WordPress actions for a table row (i.e. View, Edit, Quick Edit, Bin) on mobile because the browser tries to bring a 'drag' of a sortable element. Instead we add an icon that can be dragged instead of the whole row.

This alters the JavaScript to insert and use a 'drag icon' button with SVG into each of the targeted sortable tables. It also modifies the CSS to show the drag icon on resolutions less than 782px wide (inline with the rest of the WordPress CSS), and on larger resolutions only show the drag icon on hover of a particular table row.