### PR TITLE
Fixed for ms_switched

### DIFF
--- a/intuitive-custom-post-order.php
+++ b/intuitive-custom-post-order.php
@@ -770,10 +770,9 @@ class Hicpo
 		
 		if ( is_admin() ) return $pieces;
 		if ( 1 != $blog_id ) {
-			$current = $blog_id;
 			switch_to_blog(1);
 			$hicpo_network_sites = get_option( 'hicpo_network_sites' );
-			switch_to_blog($current);
+			restore_current_blog();
 			if ( !$hicpo_network_sites ) return $pieces;
 		} else {
 			if ( !get_option( 'hicpo_network_sites' ) ) return $pieces;
@@ -793,10 +792,9 @@ class Hicpo
 	{
 		global $blog_id;
 		if ( 1 != $blog_id ) {
-			$current = $blog_id;
 			switch_to_blog(1);
 			$hicpo_network_sites = get_option( 'hicpo_network_sites' );
-			switch_to_blog($current);
+			restore_current_blog();
 			if ( !$hicpo_network_sites ) return $blogs;
 		} else {
 			if ( !get_option( 'hicpo_network_sites' ) ) return $blogs;
@@ -856,10 +854,9 @@ class Hicpo
 		if ( version_compare( $wp_version, '4.6.0' ) < 0 ) {
 			global $blog_id;
 			if ( 1 != $blog_id ) {
-				$current = $blog_id;
 				switch_to_blog(1);
 				$hicpo_network_sites = get_option( 'hicpo_network_sites' );
-				switch_to_blog($current);
+				restore_current_blog();
 				if ( !$hicpo_network_sites ) return;
 			} else {
 				if ( !get_option( 'hicpo_network_sites' ) ) return;


### PR DESCRIPTION
https://github.com/hijiriworld/intuitive-custom-post-order/issues/38

If you are multi-site and have the Yoast SEO plugin installed, the metabox cannot be updated normally, but this is a fix for that bug.