### PR TITLE
fix(hicpo_add_capabilities): add capabilities only when role exists

### DIFF
--- a/intuitive-custom-post-order.php
+++ b/intuitive-custom-post-order.php
@@ -933,15 +933,20 @@ class Hicpo
 	function hicpo_add_capabilities()
 	{
 		$administrator = get_role( 'administrator' );
-		$administrator->add_cap( 'hicpo_load_script_css' );
-		$administrator->add_cap( 'hicpo_update_menu_order' );
-		$administrator->add_cap( 'hicpo_update_menu_order_tags' );
-		$administrator->add_cap( 'hicpo_update_menu_order_sites' );
+		if ( $administrator ) {
+			$administrator->add_cap( 'hicpo_load_script_css' );
+			$administrator->add_cap( 'hicpo_update_menu_order' );
+			$administrator->add_cap( 'hicpo_update_menu_order_tags' );
+			$administrator->add_cap( 'hicpo_update_menu_order_sites' );
+		}
 
 		$editor = get_role( 'editor' );
-		$editor->add_cap( 'hicpo_load_script_css' );
-		$editor->add_cap( 'hicpo_update_menu_order' );
-		$editor->add_cap( 'hicpo_update_menu_order_tags' );
+		if ( $editor ) {
+			$editor->add_cap( 'hicpo_load_script_css' );
+			$editor->add_cap( 'hicpo_update_menu_order' );
+			$editor->add_cap( 'hicpo_update_menu_order_tags' );
+		}
+	}
 	}
 
 }


### PR DESCRIPTION
@hijiriworld this should fix this [update-3-1-4-causes-error-if-role-doesnt-exist](https://wordpress.org/support/topic/update-3-1-4-causes-error-if-role-doesnt-exist/).