### PR TITLE
Flushing cache for object cache compatibility

### DIFF
--- a/intuitive-custom-post-order.php
+++ b/intuitive-custom-post-order.php
@@ -3,7 +3,7 @@
  * Plugin Name: Intuitive Custom Post Order
  * Plugin URI:  http://hijiriworld.com/web/plugins/intuitive-custom-post-order/
  * Description: Intuitively, Order Items (Posts, Pages, ,Custom Post Types, Custom Taxonomies, Sites) using a Drag and Drop Sortable JavaScript.
- * Version:     2023.12.14.1411
+ * Version:     2023.12.14.1435
  * Author:      hijiri
  * Author URI:  http://hijiriworld.com/web/
  * Text Domain: intuitive-custom-post-order
@@ -494,7 +494,7 @@ class Hicpo {
 		}
 
 		wp_cache_flush();
-		error_log( 'cache flush 497' )
+		error_log( 'cache flush 497' );
 
 	}
 

--- a/intuitive-custom-post-order.php
+++ b/intuitive-custom-post-order.php
@@ -3,7 +3,7 @@
  * Plugin Name: Intuitive Custom Post Order
  * Plugin URI:  http://hijiriworld.com/web/plugins/intuitive-custom-post-order/
  * Description: Intuitively, Order Items (Posts, Pages, ,Custom Post Types, Custom Taxonomies, Sites) using a Drag and Drop Sortable JavaScript.
- * Version:     2023.12.14.0727
+ * Version:     2023.12.14.1411
  * Author:      hijiri
  * Author URI:  http://hijiriworld.com/web/
  * Text Domain: intuitive-custom-post-order
@@ -494,9 +494,15 @@ class Hicpo {
 		}
 
 		wp_cache_flush();
+		error_log( 'cache flush 497' )
+
 	}
 
 	public function hicpo_update_menu_order_tags() {
+
+		wp_cache_flush();
+		error_log( 'cache flush 504 pre nonce' );
+
 		if ( ! isset( $_POST['nonce'] ) ) {
 			return;
 		}
@@ -590,6 +596,10 @@ class Hicpo {
 				$wpdb->update( $wpdb->terms, [ 'term_order' => $oreder_no ], [ 'term_id' => $id ] );
 			}
 		}
+
+		wp_cache_flush();
+		error_log( 'cache flush 601 end of hicpo_update_menu_order_tags' );
+
 	}
 
 	public function hicpo_update_menu_order_sites() {

--- a/intuitive-custom-post-order.php
+++ b/intuitive-custom-post-order.php
@@ -492,6 +492,8 @@ class Hicpo {
 				$wpdb->update( $wpdb->posts, [ 'menu_order' => $oreder_no ], [ 'ID' => intval( $id ) ] );
 			}
 		}
+
+		wp_cache_flush();
 	}
 
 	public function hicpo_update_menu_order_tags() {

--- a/intuitive-custom-post-order.php
+++ b/intuitive-custom-post-order.php
@@ -3,7 +3,7 @@
  * Plugin Name: Intuitive Custom Post Order
  * Plugin URI:  http://hijiriworld.com/web/plugins/intuitive-custom-post-order/
  * Description: Intuitively, Order Items (Posts, Pages, ,Custom Post Types, Custom Taxonomies, Sites) using a Drag and Drop Sortable JavaScript.
- * Version:     3.1.4.1
+ * Version:     2023.12.14.0727
  * Author:      hijiri
  * Author URI:  http://hijiriworld.com/web/
  * Text Domain: intuitive-custom-post-order

--- a/intuitive-custom-post-order.php
+++ b/intuitive-custom-post-order.php
@@ -3,7 +3,7 @@
  * Plugin Name: Intuitive Custom Post Order
  * Plugin URI:  http://hijiriworld.com/web/plugins/intuitive-custom-post-order/
  * Description: Intuitively, Order Items (Posts, Pages, ,Custom Post Types, Custom Taxonomies, Sites) using a Drag and Drop Sortable JavaScript.
- * Version:     2023.12.14.1435
+ * Version:     2023.12.15.0923
  * Author:      hijiri
  * Author URI:  http://hijiriworld.com/web/
  * Text Domain: intuitive-custom-post-order
@@ -494,14 +494,12 @@ class Hicpo {
 		}
 
 		wp_cache_flush();
-		error_log( 'cache flush 497' );
 
 	}
 
 	public function hicpo_update_menu_order_tags() {
 
 		wp_cache_flush();
-		error_log( 'cache flush 504 pre nonce' );
 
 		if ( ! isset( $_POST['nonce'] ) ) {
 			return;
@@ -598,7 +596,6 @@ class Hicpo {
 		}
 
 		wp_cache_flush();
-		error_log( 'cache flush 601 end of hicpo_update_menu_order_tags' );
 
 	}
 

--- a/js/hicpo.js
+++ b/js/hicpo.js
@@ -1,5 +1,5 @@
 /* global jQuery, ajaxurl, hicpojs_ajax_vars */
-
+console.log( 'hicpo loaded' );
 ( function ( $ ) {
 	const fixHelper = function ( e, ui ) {
 		ui.children()
@@ -32,6 +32,7 @@
 		helper: fixHelper,
 		// eslint-disable-next-line no-unused-vars
 		update( e, ui ) {
+			console.log( 'running term order' );
 			$.post( ajaxurl, {
 				action: 'update-menu-order-tags',
 				nonce: hicpojs_ajax_vars.nonce, // eslint-disable-line camelcase

--- a/js/hicpo.js
+++ b/js/hicpo.js
@@ -1,5 +1,4 @@
 /* global jQuery, ajaxurl, hicpojs_ajax_vars */
-console.log( 'hicpo loaded' );
 ( function ( $ ) {
 	const fixHelper = function ( e, ui ) {
 		ui.children()
@@ -32,7 +31,6 @@ console.log( 'hicpo loaded' );
 		helper: fixHelper,
 		// eslint-disable-next-line no-unused-vars
 		update( e, ui ) {
-			console.log( 'running term order' );
 			$.post( ajaxurl, {
 				action: 'update-menu-order-tags',
 				nonce: hicpojs_ajax_vars.nonce, // eslint-disable-line camelcase


### PR DESCRIPTION
When using persistent object cache the drag/drop function doesn't work because the cache isn't flushed on save. It may save in the background, but the user won't see it until the cache is flushed.

This uses the stock WordPress functions to flush the cache making persistent object cache work.