### PR TITLE
adding cache flushing

### DIFF
--- a/intuitive-custom-post-order.php
+++ b/intuitive-custom-post-order.php
@@ -492,6 +492,9 @@ class Hicpo {
 				$wpdb->update( $wpdb->posts, [ 'menu_order' => $oreder_no ], [ 'ID' => intval( $id ) ] );
 			}
 		}
+
+		// clears cache so this is compatible with object caching systems
+		wp_cache_flush();
 	}
 
 	public function hicpo_update_menu_order_tags() {
@@ -588,6 +591,9 @@ class Hicpo {
 				$wpdb->update( $wpdb->terms, [ 'term_order' => $oreder_no ], [ 'term_id' => $id ] );
 			}
 		}
+
+		// clears cache so this is compatible with object caching systems
+		wp_cache_flush();
 	}
 
 	public function hicpo_update_menu_order_sites() {
@@ -629,6 +635,9 @@ class Hicpo {
 				$wpdb->update( $wpdb->blogs, [ 'menu_order' => $position + 1 ], [ 'blog_id' => intval( $id ) ] );
 			}
 		}
+
+		// clears cache so this is compatible with object caching systems
+		wp_cache_flush();
 	}
 
 	/**


### PR DESCRIPTION
In scenarios where tools like Redis are being used the cache needs to be flushed so that the user can see the changes.

This takes the place of my previous pr: https://github.com/hijiriworld/intuitive-custom-post-order/pull/63

This still **has not** been tested with object caching in a Multisite environment as I don't have access to a Redis environment I can run Multisite on.