### PR TITLE
bug: fixes gutenberg block orderby hook

### DIFF
--- a/intuitive-custom-post-order.php
+++ b/intuitive-custom-post-order.php
@@ -855,7 +855,7 @@ class Hicpo {
 		if ( is_admin() ) {
 
 			// adminの場合 $wp_query->query['post_type']=post も渡される
-			if ( isset( $wp_query->query['post_type'] ) && ! isset( $_GET['orderby'] ) ) {
+			if ( isset( $wp_query->query['post_type'] ) && ! $wp_query->get( 'orderby' ) ) {
 				if ( in_array( $wp_query->query['post_type'], $objects ) ) {
 					$wp_query->set( 'orderby', 'menu_order' );
 					$wp_query->set( 'order', 'ASC' );


### PR DESCRIPTION
This fixes unexpected behaviour where the plugin modifies the get_posts orderby args for Gutenberg Block output, in the page editor

See: https://wordpress.org/support/topic/checking-for-getorderby-in-admin-breaks-functionality-in-blocks/