### PR TITLE
Update to upstream v3.2.0 and reapply cache flush

### DIFF
--- a/intuitive-custom-post-order.php
+++ b/intuitive-custom-post-order.php
@@ -3,7 +3,7 @@
  * Plugin Name: Intuitive Custom Post Order
  * Plugin URI:  http://hijiriworld.com/web/plugins/intuitive-custom-post-order/
  * Description: Intuitively, Order Items (Posts, Pages, ,Custom Post Types, Custom Taxonomies, Sites) using a Drag and Drop Sortable JavaScript.
- * Version:     2023.12.14.1411
+ * Version:     2023.12.14.1435
  * Author:      hijiri
  * Author URI:  http://hijiriworld.com/web/
  * Text Domain: intuitive-custom-post-order
@@ -494,7 +494,7 @@ class Hicpo {
 		}
 
 		wp_cache_flush();
-		error_log( 'cache flush 497' )
+		error_log( 'cache flush 497' );
 
 	}
 

--- a/intuitive-custom-post-order.php
+++ b/intuitive-custom-post-order.php
@@ -3,7 +3,7 @@
  * Plugin Name: Intuitive Custom Post Order
  * Plugin URI:  http://hijiriworld.com/web/plugins/intuitive-custom-post-order/
  * Description: Intuitively, Order Items (Posts, Pages, ,Custom Post Types, Custom Taxonomies, Sites) using a Drag and Drop Sortable JavaScript.
- * Version:     2023.12.14.0727
+ * Version:     2023.12.14.1411
  * Author:      hijiri
  * Author URI:  http://hijiriworld.com/web/
  * Text Domain: intuitive-custom-post-order
@@ -494,9 +494,15 @@ class Hicpo {
 		}
 
 		wp_cache_flush();
+		error_log( 'cache flush 497' )
+
 	}
 
 	public function hicpo_update_menu_order_tags() {
+
+		wp_cache_flush();
+		error_log( 'cache flush 504 pre nonce' );
+
 		if ( ! isset( $_POST['nonce'] ) ) {
 			return;
 		}
@@ -590,6 +596,10 @@ class Hicpo {
 				$wpdb->update( $wpdb->terms, [ 'term_order' => $oreder_no ], [ 'term_id' => $id ] );
 			}
 		}
+
+		wp_cache_flush();
+		error_log( 'cache flush 601 end of hicpo_update_menu_order_tags' );
+
 	}
 
 	public function hicpo_update_menu_order_sites() {

--- a/intuitive-custom-post-order.php
+++ b/intuitive-custom-post-order.php
@@ -492,6 +492,8 @@ class Hicpo {
 				$wpdb->update( $wpdb->posts, [ 'menu_order' => $oreder_no ], [ 'ID' => intval( $id ) ] );
 			}
 		}
+
+		wp_cache_flush();
 	}
 
 	public function hicpo_update_menu_order_tags() {

--- a/intuitive-custom-post-order.php
+++ b/intuitive-custom-post-order.php
@@ -3,7 +3,7 @@
  * Plugin Name: Intuitive Custom Post Order
  * Plugin URI:  http://hijiriworld.com/web/plugins/intuitive-custom-post-order/
  * Description: Intuitively, Order Items (Posts, Pages, ,Custom Post Types, Custom Taxonomies, Sites) using a Drag and Drop Sortable JavaScript.
- * Version:     3.1.4.1
+ * Version:     2023.12.14.0727
  * Author:      hijiri
  * Author URI:  http://hijiriworld.com/web/
  * Text Domain: intuitive-custom-post-order

--- a/intuitive-custom-post-order.php
+++ b/intuitive-custom-post-order.php
@@ -3,7 +3,7 @@
  * Plugin Name: Intuitive Custom Post Order
  * Plugin URI:  http://hijiriworld.com/web/plugins/intuitive-custom-post-order/
  * Description: Intuitively, Order Items (Posts, Pages, ,Custom Post Types, Custom Taxonomies, Sites) using a Drag and Drop Sortable JavaScript.
- * Version:     2023.12.14.1435
+ * Version:     2023.12.15.0923
  * Author:      hijiri
  * Author URI:  http://hijiriworld.com/web/
  * Text Domain: intuitive-custom-post-order
@@ -494,14 +494,12 @@ class Hicpo {
 		}
 
 		wp_cache_flush();
-		error_log( 'cache flush 497' );
 
 	}
 
 	public function hicpo_update_menu_order_tags() {
 
 		wp_cache_flush();
-		error_log( 'cache flush 504 pre nonce' );
 
 		if ( ! isset( $_POST['nonce'] ) ) {
 			return;
@@ -598,7 +596,6 @@ class Hicpo {
 		}
 
 		wp_cache_flush();
-		error_log( 'cache flush 601 end of hicpo_update_menu_order_tags' );
 
 	}
 

--- a/js/hicpo.js
+++ b/js/hicpo.js
@@ -1,5 +1,5 @@
 /* global jQuery, ajaxurl, hicpojs_ajax_vars */
-
+console.log( 'hicpo loaded' );
 ( function ( $ ) {
 	const fixHelper = function ( e, ui ) {
 		ui.children()
@@ -32,6 +32,7 @@
 		helper: fixHelper,
 		// eslint-disable-next-line no-unused-vars
 		update( e, ui ) {
+			console.log( 'running term order' );
 			$.post( ajaxurl, {
 				action: 'update-menu-order-tags',
 				nonce: hicpojs_ajax_vars.nonce, // eslint-disable-line camelcase

--- a/js/hicpo.js
+++ b/js/hicpo.js
@@ -1,5 +1,4 @@
 /* global jQuery, ajaxurl, hicpojs_ajax_vars */
-console.log( 'hicpo loaded' );
 ( function ( $ ) {
 	const fixHelper = function ( e, ui ) {
 		ui.children()
@@ -32,7 +31,6 @@ console.log( 'hicpo loaded' );
 		helper: fixHelper,
 		// eslint-disable-next-line no-unused-vars
 		update( e, ui ) {
-			console.log( 'running term order' );
 			$.post( ajaxurl, {
 				action: 'update-menu-order-tags',
 				nonce: hicpojs_ajax_vars.nonce, // eslint-disable-line camelcase


### PR DESCRIPTION
## What upstream v3.2.0 brings in

- **Capability-name dedup fix** — removes the duplicated `hicpo_` prefix in `hicpo_load_script_css` capability name (merged from PR #66 / #68, commit ec9a21a).
- **Gutenberg orderby hook fix** — corrects the block editor orderby hook so drag-and-drop ordering applies correctly in Gutenberg (commit 1150b6f).
- **June 2024 hook fix** — additional hook registration fix (commit 15e36b5 via PR #67 from EarthmanWeb).
- **3.2.0 SVN sync** — syncs tag with SVN trunk; includes per-action capability checks (`hicpo_update_menu_order`, `hicpo_update_menu_order_sites` are now separate capabilities), a11y announcements in the JS reorder response, and refactored AJAX handlers with `check_ajax_referer()` replacing manual nonce checks.

## Our customization: `wp_cache_flush()` reapplied

ProudCity runs Redis object caching. Without an explicit cache flush after drag-and-drop reordering, Redis serves stale ordering until the TTL expires. This was first added in proudcity/wp-proudcity#2445.

After taking upstream v3.2.0 verbatim, `wp_cache_flush()` was reapplied in **three AJAX order-save handlers** — one per handler, after the primary reorder loop and before the `// same number check` section (or before `wp_send_json_success` in the sites handler):

- `hicpo_update_menu_order()` — line 475
- `hicpo_update_menu_order_tags()` — line 580
- `hicpo_update_menu_order_sites()` — line 682

Each call is preceded by the comment:
```
// ProudCity: flush object cache so Redis serves fresh ordering (proudcity/wp-proudcity#2445).
```

## Verification

```bash
diff -u <pristine-3.2.0>/intuitive-custom-post-order.php intuitive-custom-post-order.php
```

The diff shows **only the three flush hunks** — no other changes vs a clean upstream 3.2.0 checkout. `js/hicpo.js` is byte-for-byte identical to upstream.

PHPCS passes on our added lines. CSS stylelint errors are pre-existing upstream issues unrelated to this merge.

## Follow-up

Check whether [our upstream PR hijiriworld#64](https://github.com/hijiriworld/intuitive-custom-post-order/pull/64) was merged into a release newer than 3.2.0. If so, cache flushing will be built-in upstream and we can drop the fork and pull directly.

Closes proudcity/wp-proudcity#2854